### PR TITLE
Add test generator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,62 @@ Adding the following to your parser after installing will solve this issue:
 
 * `ember install:addon ember-cli-eslint`
 
+## Adding a Test Generator
+
+You may want to generate tests that pass/fail based on the eslint result.
+
+You can pass a `testGenerator` function to `EmberApp`. Use the `eslint` option.
+
+Example:
+
+```javascript
+// Brocfile.js
+
+var path = require('path');
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+// `npm install --save-dev js-string-escape`
+var jsStringEscape = require('js-string-escape');
+
+var app = new EmberApp({
+  eslint: {
+    testGenerator: eslintTestGenerator
+  }
+});
+
+function render(errors) {
+  if (!errors) { return ''; };
+  return errors.map(function(error) {
+    return error.line + ':' + error.column + ' ' +
+      ' - ' + error.message + ' (' + error.ruleId +')';
+  }).join('\n');
+}
+
+// Qunit test generator
+function eslintTestGenerator(relativePath, errors) {
+  var pass = !errors || errors.length === 0;
+  return "import { module, test } from 'qunit';\n" +
+    "module('ESLint - " + path.dirname(relativePath) + "');\n" +
+    "test('" + relativePath + " should pass ESLint', function(assert) {\n" +
+    "  assert.ok(" + pass + ", '" + relativePath + " should pass ESLint." +
+    jsStringEscape("\n" + render(errors)) + "');\n" +
+   "});\n";
+}
+
+// Mocha test generator
+function eslintTestGenerator(relativePath, errors) {
+  var pass = !errors || errors.length === 0;
+  return "import { describe, it } from 'mocha';\n" +
+    "import { assert } from 'chai';\n" +
+    "describe('ESLint - " + path.dirname(relativePath) + "', function() {\n" +
+    "  it('" + relativePath + " should pass ESLint', function() {\n" +
+    "    assert.ok(" + pass + ", '" + relativePath + " should pass ESLint." +
+    jsStringEscape("\n" + render(errors)) + "');\n" +
+   "  });\n});\n";
+}
+
+```
+
+
 ## Licence
 
 The MIT License (MIT)

--- a/index.js
+++ b/index.js
@@ -7,11 +7,21 @@ module.exports = {
   included: function (app) {
     this._super.included(app);
     this.jshintrc = app.options.jshintrc;
+    this.options = app.options.eslint || {};
   },
   lintTree: function(type, tree) {
     return eslint(tree, {
       config: this.jshintrc.app + '/eslint.json',
-      rulesdir: this.jshintrc.app
+      rulesdir: this.jshintrc.app,
+      testGenerator: this.options.testGenerator || generateEmptyTest
     });
   }
 };
+
+// Empty test generator. The reason we do that is that `lintTree`
+// will merge the returned tree with the `tests` directory anyway,
+// so we minimize the damage by returning empty files instead of
+// duplicating app tree.
+function generateEmptyTest() {
+  return '';
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
-    "broccoli-lint-eslint": "^0.1.0"
+    "broccoli-lint-eslint": "^0.1.1"
   }
 }


### PR DESCRIPTION
**Do not merge - depends on a custom broccoli-lint-eslint branch**

----
Depends on https://github.com/jonathanKingston/broccoli-lint-eslint/pull/2

I added an empty test generator because I'm not sure if you'd like to pick a default testing framework (which should probably be qunit since it is ember-cli's default).

Here is my test generator. I will happily add it to this PR if you' d like.
```javascript
var app = new EmberApp({
  eslint: {
    testGenerator: eslintTestGenerator
  }
});

function eslintTestGenerator(relativePath, errors) {
  var pass = !errors || errors.length === 0;
  return "module('ESLINT - " + path.dirname(relativePath) + "');\n" +
    "test('" + relativePath + " should pass eslint', function() {\n" +
    "  ok(" + pass + ", '" + relativePath + " should pass eslint." + 
    errors.map(function(item) { return item.message; }).join('\n') + "');\n" +
   "});\n";
}
```
