### PR TITLE
Export test generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ ESLinting for Ember CLI apps, [ESLint](http://eslint.org/) provides a scriptable
 
 babel-eslint parser will solve any new ECMA missing functionality in ESLint.
 
-Adding the following to your parser after installing will solve this issue:
+Adding the following to your .eslintrc file after installing will solve this issue:
+
 ```
     "parser": "babel-eslint",
 ```
@@ -22,9 +23,11 @@ Adding the following to your parser after installing will solve this issue:
 
 ## Adding a Test Generator
 
-You may want to generate tests that pass/fail based on the eslint result.
+You may want to generate tests that pass or fail based on the ESLint result.
 
-You can pass a `testGenerator` function to `EmberApp`. Use the `eslint` option.
+You can pass a `testGenerator` function to `EmberApp` via the `eslint` option.
+Ember-cli-eslint offers two such test generators out of the box: `qunit` and
+`mocha`.
 
 Example:
 
@@ -33,47 +36,17 @@ Example:
 
 var path = require('path');
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
-// `npm install --save-dev js-string-escape`
-var jsStringEscape = require('js-string-escape');
+var testGenerators = require('ember-cli-eslint/test-generators');
 
 var app = new EmberApp({
   eslint: {
-    testGenerator: eslintTestGenerator
+    testGenerator: testGenerators.qunit // or testGenerators.mocha
   }
 });
-
-function render(errors) {
-  if (!errors) { return ''; }
-  return errors.map(function(error) {
-    return error.line + ':' + error.column + ' ' +
-      ' - ' + error.message + ' (' + error.ruleId +')';
-  }).join('\n');
-}
-
-// Qunit test generator
-function eslintTestGenerator(relativePath, errors) {
-  var pass = !errors || errors.length === 0;
-  return "import { module, test } from 'qunit';\n" +
-    "module('ESLint - " + path.dirname(relativePath) + "');\n" +
-    "test('" + relativePath + " should pass ESLint', function(assert) {\n" +
-    "  assert.ok(" + pass + ", '" + relativePath + " should pass ESLint." +
-    jsStringEscape("\n" + render(errors)) + "');\n" +
-   "});\n";
-}
-
-// Mocha test generator
-function eslintTestGenerator(relativePath, errors) {
-  var pass = !errors || errors.length === 0;
-  return "import { describe, it } from 'mocha';\n" +
-    "import { assert } from 'chai';\n" +
-    "describe('ESLint - " + path.dirname(relativePath) + "', function() {\n" +
-    "  it('" + relativePath + " should pass ESLint', function() {\n" +
-    "    assert.ok(" + pass + ", '" + relativePath + " should pass ESLint." +
-    jsStringEscape("\n" + render(errors)) + "');\n" +
-   "  });\n});\n";
-}
-
 ```
+
+You can also write your own `testGenerator` function. See
+[test-generators.js](test-generators.js) for help getting starting with that.
 
 ## Running tests
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,37 +1,14 @@
 /* jshint node: true */
 /* global require, module */
-var path = require('path');
-var jsStringEscape = require('js-string-escape');
+var testGenerators = require('./test-generators');
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function (defaults) {
   var app = new EmberAddon({
     eslint: {
-      testGenerator: eslintTestGenerator
+      testGenerator: testGenerators.qunit
     }
   });
-
-
-  function render(errors) {
-    if (!errors) {
-      return '';
-    }
-    return errors.map(function (error) {
-      return error.line + ':' + error.column + ' ' +
-        ' - ' + error.message + ' (' + error.ruleId + ')';
-    }).join('\n');
-  }
-
-  // Qunit test generator
-  function eslintTestGenerator(relativePath, errors) {
-    var pass = !errors || errors.length === 0;
-    return "import { module, test } from 'qunit';\n" +
-      "module('ESLint - " + path.dirname(relativePath) + "');\n" +
-      "test('" + relativePath + " should pass ESLint', function(assert) {\n" +
-      "  assert.ok(" + pass + ", '" + relativePath + " should pass ESLint." +
-      jsStringEscape("\n" + render(errors)) + "');\n" +
-      "});\n";
-  }
 
   // Use `app.import` to add additional libraries to the generated
   // output files.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ember-try": "0.0.8",
     "eslint-config-ember": "^0.1.1",
     "express": "^4.12.3",
-    "js-string-escape": "^1.0.0",
     "phantomjs": "^1.9.16"
   },
   "keywords": [
@@ -60,6 +59,7 @@
     "defaultBlueprint": "ember-cli-eslint"
   },
   "dependencies": {
-    "broccoli-lint-eslint": "^1.1.1"
+    "broccoli-lint-eslint": "^1.1.1",
+    "js-string-escape": "^1.0.0"
   }
 }

--- a/test-generators.js
+++ b/test-generators.js
@@ -1,0 +1,42 @@
+/* jshint node: true */
+/* global require, module */
+var path = require('path');
+var jsStringEscape = require('js-string-escape');
+
+module.exports = {
+  qunit: qunitTestGenerator,
+  mocha: mochaTestGenerator
+};
+
+function render(errors) {
+  if (!errors) {
+    return '';
+  }
+  return errors.map(function (error) {
+    return error.line + ':' + error.column + ' ' +
+      ' - ' + error.message + ' (' + error.ruleId + ')';
+  }).join('\n');
+}
+
+// Qunit test generator
+function qunitTestGenerator(relativePath, errors) {
+  var pass = !errors || errors.length === 0;
+  return "import { module, test } from 'qunit';\n" +
+    "module('ESLint - " + path.dirname(relativePath) + "');\n" +
+    "test('" + relativePath + " should pass ESLint', function(assert) {\n" +
+    "  assert.expect(1);\n  assert.ok(" + pass + ", '" + relativePath +
+    " should pass ESLint." + jsStringEscape("\n" + render(errors)) + "');\n" +
+    "});\n";
+}
+
+// Mocha test generator
+function mochaTestGenerator(relativePath, errors) {
+  var pass = !errors || errors.length === 0;
+  return "import { describe, it } from 'mocha';\n" +
+    "import { assert } from 'chai';\n" +
+    "describe('ESLint - " + path.dirname(relativePath) + "', function() {\n" +
+    "  it('" + relativePath + " should pass ESLint', function() {\n" +
+    "    assert.ok(" + pass + ", '" + relativePath + " should pass ESLint." +
+    jsStringEscape("\n" + render(errors)) + "');\n" +
+    "  });\n});\n";
+}


### PR DESCRIPTION
Move the provided test generators from the README into the code. Doing so makes them available for use by consuming modules:

```javascript
var testGenerators = require('ember-cli-eslint/test-generators');

var app = new EmberApp({
  eslint: {
    testGenerator: testGenerators.mocha
  }
});
```

Depends on #26 or a similar build fix.