### PR TITLE
Disable ember-cli-qunit's lintTree hook.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,17 @@ var eslint = require('broccoli-lint-eslint');
 
 module.exports = {
   name: 'ember-cli-eslint',
+
+  // instructs ember-cli-qunit and ember-cli-mocha to
+  // disable their lintTree implementations (which use JSHint)
+  isDefaultJSLinter: true,
+
   included: function (app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
     this.jshintrc = app.options.jshintrc;
     this.options = app.options.eslint || {};
   },
+
   lintTree: function(type, tree) {
     return eslint(tree, {
       testGenerator: this.options.testGenerator || generateEmptyTest


### PR DESCRIPTION
This prevents running both JSHint and ESLint.

As of https://github.com/ember-cli/ember-cli-qunit/pull/102 ember-cli-qunit's `lintTree` hook is disabled when this property is present on another addon.