### PR TITLE
Updated to install latest version of eslint-config-ember

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 ---
 language: node_js
+node_js:
+  - "4.2.4"
 
 sudo: false
 

--- a/blueprints/ember-cli-eslint/index.js
+++ b/blueprints/ember-cli-eslint/index.js
@@ -8,6 +8,6 @@ module.exports = {
   },
 
   afterInstall: function () {
-    return this.addPackageToProject('eslint-config-ember', '^0.0.5');
+    return this.addPackageToProject('eslint-config-ember', '^0.2.1');
   }
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-data": "1.0.0-beta.18",
     "ember-export-application-global": "~1.0.3",
     "ember-try": "0.0.8",
-    "eslint-config-ember": "^0.2.1",
+    "eslint-config-ember": "^0.1.1",
     "express": "^4.12.3",
     "js-string-escape": "^1.0.0",
     "phantomjs": "^1.9.16"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-data": "1.0.0-beta.18",
     "ember-export-application-global": "~1.0.3",
     "ember-try": "0.0.8",
-    "eslint-config-ember": "^0.1.1",
+    "eslint-config-ember": "^0.2.1",
     "express": "^4.12.3",
     "js-string-escape": "^1.0.0",
     "phantomjs": "^1.9.16"

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,10 +21,11 @@
 
     {{content-for 'body'}}
     {{content-for 'test-body'}}
+    <script src="testem.js" integrity=""></script>
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>
     <script src="assets/dummy.js"></script>
-    <script src="testem.js"></script>
+    <script src="assets/tests.js"></script>
     <script src="assets/test-loader.js"></script>
 
     {{content-for 'body-footer'}}


### PR DESCRIPTION
This addresses issues #20 and #28.  

Regarding #20:
Currently the `0.0.5` version of `eslint-config-ember` that `ember-cli-eslint` extends is using a version of `eslint` prior to 1.0. This seems to lead to error messages during `ember-cli-eslint`'s linter phase stating things such as: `error  Rule 'no-comma-dangle' was removed and replaced by: comma-dangle`.

Since `eslint-config-ember` itself has long-since been updated to use a version of `eslint` > 1.0, this should clear up those issues.

Regarding #28:
This was an issue for me both locally and in CI. 

It seems reasonable that the dev-dependency should use the latest of the "Valid install targets". Once I made this change, I started seeing an error in Travis stating `DEPRECATION: Node v0.10.42 is no longer supported by Ember CLI. Please update to a more recent version of Node`. I updated `.travis.yml` accordingly to tell it to use Node @ 4.2.4.
