### PR TITLE
Fix declaration of "dependencies" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,11 @@
     "loader.js": "^4.0.0",
     "phantomjs": "^2.1.3"
   },
+  "dependencies": {
+    "broccoli-lint-eslint": "^1.1.1",
+    "ember-cli-babel": "^5.1.5",
+    "js-string-escape": "^1.0.0"
+  },
   "keywords": [
     "ember-addon",
     "lint",
@@ -57,19 +62,11 @@
     "eslint ember-cli",
     "ember"
   ],
-  "dependencies": {
-    "broccoli-lint-eslint": "^1.1.1",
-    "ember-cli-babel": "^5.1.5"
-  },
   "main": "index.js",
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "before": "ember-cli-qunit",
     "main": "index.js",
     "defaultBlueprint": "ember-cli-eslint"
-  },
-  "dependencies": {
-    "broccoli-lint-eslint": "^1.1.1",
-    "js-string-escape": "^1.0.0"
   }
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -27,7 +27,6 @@
     <script src="assets/dummy.js"></script>
     <script src="assets/tests.js"></script>
     <script src="assets/test-loader.js"></script>
-    <script src="assets/tests.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}


### PR DESCRIPTION
This PR addresses #34 where tests weren't being transpiled. 

Somewhere along the way in the last few commits, we seem to have accidentally declared the `dependencies` hash in `package.json` twice. The last one wins... and it was the one without `ember-cli-babel` :flushed:.

There was also a duplicate `assets/tests.js` script inside of `tests/index.html` that I took care of deleting. 

These changes should get us green in CI. 