### PR TITLE
Bump the version dependency for broccoli-lint-eslint.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Jonathan Kingston",
   "license": "MIT",
   "devDependencies": {
-    "babel-eslint": "^5.0.0",
+    "babel-eslint": "^6.0.0-beta.6",
     "broccoli-asset-rev": "^2.2.0",
     "ember-ajax": "0.7.1",
     "ember-cli": "^2.3.0",
@@ -44,13 +44,13 @@
     "ember-load-initializers": "^0.5.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.1.2",
-    "eslint-config-ember": "^0.2.1",
+    "eslint-config-ember": "^0.3.0",
     "express": "^4.12.3",
     "loader.js": "^4.0.0",
     "phantomjs": "^2.1.3"
   },
   "dependencies": {
-    "broccoli-lint-eslint": "^1.1.1",
+    "broccoli-lint-eslint": "^2.0.0",
     "ember-cli-babel": "^5.1.5",
     "js-string-escape": "^1.0.0"
   },


### PR DESCRIPTION
This *should* (and in my local testing *does*) resolve the problem with tokenization from broccoli-lint-eslint using ES6 features, and so resolves #38.