### PR TITLE
update eslint-config-ember version installed by addon and add `afterUninstall` hook

### DIFF
--- a/blueprints/ember-cli-eslint/index.js
+++ b/blueprints/ember-cli-eslint/index.js
@@ -8,6 +8,10 @@ module.exports = {
   },
 
   afterInstall: function () {
-    return this.addPackageToProject('eslint-config-ember', '^0.2.1');
-  }
+    return this.addPackageToProject('eslint-config-ember', '^0.3.0');
+  },
+
+  afterUninstall: function () {
+    return this.removePackageFromProject('eslint-config-ember');
+  },
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Jonathan Kingston",
   "license": "MIT",
   "devDependencies": {
-    "babel-eslint": "^5.0.0",
+    "babel-eslint": "^6.0.0-beta.6",
     "broccoli-asset-rev": "^2.2.0",
     "ember-ajax": "0.7.1",
     "ember-cli": "^2.3.0",
@@ -44,13 +44,13 @@
     "ember-load-initializers": "^0.5.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.1.2",
-    "eslint-config-ember": "^0.2.1",
+    "eslint-config-ember": "^0.3.0",
     "express": "^4.12.3",
     "loader.js": "^4.0.0",
     "phantomjs": "^2.1.3"
   },
   "dependencies": {
-    "broccoli-lint-eslint": "^1.1.1",
+    "broccoli-lint-eslint": "^2.0.0",
     "ember-cli-babel": "^5.1.5",
     "js-string-escape": "^1.0.0"
   },


### PR DESCRIPTION
This PR is meant to coincide with https://github.com/jonathanKingston/ember-cli-eslint/pull/39/files and depends on getting `eslint-config-ember` to 0.3.0 with https://github.com/jonathanKingston/eslint-config-ember/pull/7. 

It ensures that the `eslint-config-ember` package we're adding to consumer projects is also at  0.3.0, and I also added logic for `afterUninstall` that cleans up the package if some decides to uninstall.