### PR TITLE
Don't lint the template tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ module.exports = {
   lintTree: function(type, tree) {
     var project = this.project;
 
+    if (type === 'templates') {
+      return;
+    }
+
     return eslint(tree, {
       testGenerator: this.options.testGenerator || function(relativePath, errors) {
         if (!project.generateTestFile) {


### PR DESCRIPTION
Don't attempt to lint the template tree.

This will fix build failure caused by merging jonathanKingston/broccoli-lint-eslint#25.