### PR TITLE
Install latest version of ember-cli-release (1.1.0-beta.1)

### DIFF
--- a/config/release.js
+++ b/config/release.js
@@ -1,0 +1,21 @@
+/* jshint node:true */
+// var RSVP = require('rsvp');
+
+// For details on each option run `ember help release`
+module.exports = {
+  // local: true,
+  // remote: 'some_remote',
+  // annotation: "Release %@",
+  // message: "Bumped version to %@",
+  // manifest: [ 'package.json', 'bower.json', 'someconfig.json' ],
+  // publish: true,
+  // strategy: 'date',
+  // format: 'YYYY-MM-DD',
+  // timezone: 'America/Los_Angeles',
+  //
+  // beforeCommit: function(project, versions) {
+  //   return new RSVP.Promise(function(resolve, reject) {
+  //     // Do custom things here...
+  //   });
+  // }
+};

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.2.1",
-    "ember-cli-release": "0.2.8",
+    "ember-cli-release": "1.0.0-beta.1",
     "ember-cli-sri": "^2.0.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",


### PR DESCRIPTION
To address #49, I drafted a release for the current version of the package (1.2.1), and also updated to the latest version of [ember-cli-relase](https://github.com/lytics/ember-cli-release) with the hopes that we can use it going forward. 

Also, I was trying to see if I could draft a release for 1.2.0 by using the [commit hash from when that became the latest version](https://github.com/jonathanKingston/ember-cli-eslint/commit/5aba58a83e8ad36be5bd781c6afe911ff40d9fa6), but the selection tool on the release drafting page only exposes "Recent Commits" -- which apparently doesn't go as far back as our 1.2.0 bump. If anyone knows how to draft a release for _any_ specific commit, I'd be super curious to know how. At the very least, though, these changes will put us on the right track going forward. 