### PR TITLE
Update rules used by dummy app to fix test linting

### DIFF
--- a/config/eslint-tests.js
+++ b/config/eslint-tests.js
@@ -9,6 +9,10 @@ module.exports = {
     "space-before-function-paren": [0, { "anonymous": "always", "named": "always" }],
     "object-curly-spacing": [2, "always"],
     "prefer-reflect": 0,
-    "newline-after-var": 0
+    "newline-after-var": 0,
+    "arrow-spacing": 0,
+    "array-callback-return": 0,
+    "no-empty-function": 0,
+    "prefer-rest-params": 0    
   }
 };


### PR DESCRIPTION
This is minor change to follow-up on https://github.com/jonathanKingston/ember-cli-eslint/pull/47.

Now that `broccoli-lint-eslint` has been updated to detect nested configs, the config being used in the dummy app is -- as it's supposed to -- overriding the root... and so the additions made in #47 don't quite cover everything in the dummy app. 

I plan to do a bit more refactoring into how our local linting set up, but I just wanted to get this in as a minor change before bumping to `1.3.0`.